### PR TITLE
Added two required options.

### DIFF
--- a/lib/bom_builder.rb
+++ b/lib/bom_builder.rb
@@ -81,6 +81,12 @@ class Bombuilder
       opts.on('-p', '--path path', '(Required) Path to Ruby project directory') do |path|
         @options[:path] = path
       end
+      opts.on('-n', '--name proj_name', '(Required) Project name <org/repo>') do |proj_name|
+        @options[:proj_name] = proj_name
+      end
+      opts.on('-r', '--rendition rendition', '(Required) Project Version') do |rendition|
+        @options[:rendition] = rendition
+      end
       opts.on('-o', '--output bom_file_path', '(Optional) Path to output the bom.xml file to') do |bom_file_path|
         @options[:bom_file_path] = bom_file_path
       end
@@ -103,6 +109,16 @@ class Bombuilder
 
     if @options[:path].nil?
       @logger.error('missing path to project directory')
+      abort
+    end
+
+    if @options[:proj_name].nil?
+      @logger.error('missing project name')
+      abort
+    end
+
+    if @options[:rendition].nil?
+      @logger.error('missing project version')
       abort
     end
 

--- a/lib/bom_helpers.rb
+++ b/lib/bom_helpers.rb
@@ -33,6 +33,12 @@ def build_bom(gems)
   builder = Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
     attributes = { 'xmlns' => 'http://cyclonedx.org/schema/bom/1.3', 'version' => '1', 'serialNumber' => random_urn_uuid }
     xml.bom(attributes) do
+      xml.metadata do
+        xml.component('type' => 'application') do
+          xml.name @options[:proj_name]
+          xml.version @options[:rendition]
+        end  
+      end
       xml.components do
         gems.each do |gem|
           xml.component('type' => 'library') do


### PR DESCRIPTION
--name <project name>
--rendition <project version>

This allows for a metadata section in the Ruby Software Bill of Materials.
The metadata section is required to successfully generate a single hierarchical merged SBOM.

### Desired Outcome

Added metadata section to SBOM output.

### Implemented Changes

Added required options that a caller must specify when generating a Ruby SBOM.
